### PR TITLE
feature: add example generator

### DIFF
--- a/templates/ContractTemplates/src/typescript-generator/.gitignore
+++ b/templates/ContractTemplates/src/typescript-generator/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/templates/ContractTemplates/src/typescript-generator/README.md
+++ b/templates/ContractTemplates/src/typescript-generator/README.md
@@ -1,0 +1,27 @@
+# Typescript Generator
+
+This is an example typescript generator to generate typescript definitions for Proto files using protoc.
+
+## Installation
+
+First, make sure that protoc is installed and also nodejs.
+
+```bash
+npm install
+```
+
+## Usage
+
+### Delete existing dist folder (if any) and regenerate the files in dist
+
+```bash
+npm start
+```
+
+### How to use
+
+Please see [example.ts](example.ts) for some usage examples.
+
+## References
+
+- [ts-proto](https://github.com/stephenh/ts-proto)

--- a/templates/ContractTemplates/src/typescript-generator/example.ts
+++ b/templates/ContractTemplates/src/typescript-generator/example.ts
@@ -1,0 +1,56 @@
+import {
+  BingoGameContract,
+  BoutInformation,
+  GetBoutInformationInput,
+  LimitSettings,
+  PlayInput,
+  PlayerInformation,
+} from "./dist/Protobuf/contract/bingo_game_contract";
+import { Hash, Address } from "./dist/aelf/core";
+import { Empty } from "./dist/google/protobuf/empty";
+import {
+  Int64Value,
+  BoolValue,
+  Int32Value,
+} from "./dist/google/protobuf/wrappers";
+
+/**
+ * The following methods can be implemented such that it follows the generated types in dist
+ */
+export class BingoGameService implements BingoGameContract {
+  Register(request: Empty): Promise<Empty> {
+    throw new Error("Method not implemented.");
+  }
+  Play(request: PlayInput): Promise<Int64Value> {
+    throw new Error("Method not implemented.");
+  }
+  Bingo(request: Hash): Promise<BoolValue> {
+    throw new Error("Method not implemented.");
+  }
+  Quit(request: Empty): Promise<Empty> {
+    throw new Error("Method not implemented.");
+  }
+  SetLimitSettings(request: LimitSettings): Promise<Empty> {
+    throw new Error("Method not implemented.");
+  }
+  Initialize(request: Empty): Promise<Empty> {
+    throw new Error("Method not implemented.");
+  }
+  GetAward(request: Hash): Promise<Int64Value> {
+    throw new Error("Method not implemented.");
+  }
+  GetPlayerInformation(request: Address): Promise<PlayerInformation> {
+    throw new Error("Method not implemented.");
+  }
+  GetLimitSettings(request: Empty): Promise<LimitSettings> {
+    throw new Error("Method not implemented.");
+  }
+  GetRandomNumber(request: Hash): Promise<Int32Value> {
+    throw new Error("Method not implemented.");
+  }
+  GetBoutInformation(
+    request: GetBoutInformationInput
+  ): Promise<BoutInformation> {
+    throw new Error("Method not implemented.");
+  }
+}

--- a/templates/ContractTemplates/src/typescript-generator/package-lock.json
+++ b/templates/ContractTemplates/src/typescript-generator/package-lock.json
@@ -1,0 +1,164 @@
+{
+  "name": "typescript-generator",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "typescript-generator",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "ts-proto": "^1.155.1"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
+    "node_modules/@types/node": {
+      "version": "20.4.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.2.tgz",
+      "integrity": "sha512-Dd0BYtWgnWJKwO1jkmTrzofjK2QXXcai0dmtzvIBhcA+RsG5h8R3xlyta0kGOZRNfL9GuRtb1knmPEhQrePCEw=="
+    },
+    "node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+      "bin": {
+        "detect-libc": "bin/detect-libc.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/dprint-node": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/dprint-node/-/dprint-node-1.0.7.tgz",
+      "integrity": "sha512-NTZOW9A7ipb0n7z7nC3wftvsbceircwVHSgzobJsEQa+7RnOMbhrfX5IflA6CtC4GA63DSAiHYXa4JKEy9F7cA==",
+      "dependencies": {
+        "detect-libc": "^1.0.3"
+      }
+    },
+    "node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+    },
+    "node_modules/protobufjs": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
+      "integrity": "sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/ts-poet": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/ts-poet/-/ts-poet-6.5.0.tgz",
+      "integrity": "sha512-44jURLT1HG6+NsDcadM826V6Ekux+wk07Go+MX5Gfx+8zcPKfUiFEtnjL9imuRVGSCRtloRLqw4bDGZVJYGZMQ==",
+      "dependencies": {
+        "dprint-node": "^1.0.7"
+      }
+    },
+    "node_modules/ts-proto": {
+      "version": "1.155.1",
+      "resolved": "https://registry.npmjs.org/ts-proto/-/ts-proto-1.155.1.tgz",
+      "integrity": "sha512-7dGkBFJu8NVl1OJbRjcKKs05hUNcLhFXTJqI5GphkmLCKoid0SBVKhW0q1j0c0LgCZB/zoFv4L5ibgFzIB6kPQ==",
+      "dependencies": {
+        "case-anything": "^2.1.13",
+        "protobufjs": "^7.2.4",
+        "ts-poet": "^6.5.0",
+        "ts-proto-descriptors": "1.14.0"
+      },
+      "bin": {
+        "protoc-gen-ts_proto": "protoc-gen-ts_proto"
+      }
+    },
+    "node_modules/ts-proto-descriptors": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/ts-proto-descriptors/-/ts-proto-descriptors-1.14.0.tgz",
+      "integrity": "sha512-xqLA6cBTfof+mZ/sIw/pZviyhnWWcWqRBjyjaMW5O4fIogpawT4aa0wI8rKh0rYIrQzoHxLugmFu4+rdiWaGEQ==",
+      "dependencies": {
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.4"
+      }
+    }
+  }
+}

--- a/templates/ContractTemplates/src/typescript-generator/package.json
+++ b/templates/ContractTemplates/src/typescript-generator/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "typescript-generator",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "prestart": "rm -rf dist && mkdir dist",
+    "start": "protoc --plugin=node_modules/ts-proto/protoc-gen-ts_proto --ts_proto_opt=esModuleInterop=true --ts_proto_opt=exportCommonSymbols=false --ts_proto_out=dist -I=../ Protobuf/contract/bingo_game_contract.proto"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "ts-proto": "^1.155.1"
+  }
+}


### PR DESCRIPTION
Note: example.ts class is auto generated by IDE VS Code when importing it, and clicking on "Quick Fix":
<img width="603" alt="image" src="https://github.com/AElfProject/aelf-developer-tools/assets/132553186/b4153d11-5296-485c-8276-c4e2f32aa095">

The user will then need to import **aelf-sdk** or **aelf-web-login** library to implement these service methods using those libraries.

I have purposefully excluded the **dist** folder as it is generated and should not be included as part of the source.