### PR TITLE
CI/CD for AElf.ContractTemplates

### DIFF
--- a/.github/workflows/publish-templates-prod.yml
+++ b/.github/workflows/publish-templates-prod.yml
@@ -31,8 +31,6 @@ jobs:
         run: dotnet pack --configuration Release --output nupkgs /p:Version=$VERSION
 
       - name: Publish NuGet packages
-        uses: dansiegel/publish-nuget@v1.2
-        with:
-          filename: '**/*.nupkg'
-          apiKey: ${{ secrets.TEST_NUGET_API_KEY }}
-          feedUrl: ${{ secrets.TEST_NUGET_FEED_URL }}
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+        run: |
+          dotnet nuget push "nupkgs/*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source $NUGET_SOURCE_URL

--- a/.github/workflows/publish-templates-prod.yml
+++ b/.github/workflows/publish-templates-prod.yml
@@ -24,7 +24,7 @@ jobs:
         working-directory: ${{ env.WORKING_DIRECTORY }}
         run: |
           version=$(grep -oP '<Version>\K[^<]+' Version.props)
-          echo "VERSION=$version-rc.${GITHUB_RUN_NUMBER}" >> $GITHUB_ENV
+          echo "VERSION=$version" >> $GITHUB_ENV
 
       - name: Pack
         working-directory: ${{ env.WORKING_DIRECTORY }}
@@ -33,4 +33,4 @@ jobs:
       - name: Publish NuGet packages
         working-directory: ${{ env.WORKING_DIRECTORY }}
         run: |
-          dotnet nuget push "nupkgs/*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source $NUGET_SOURCE_URL
+          dotnet nuget push "nupkgs/*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source ${{ vars.NUGET_SOURCE_URL }}

--- a/.github/workflows/publish-templates-prod.yml
+++ b/.github/workflows/publish-templates-prod.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       WORKING_DIRECTORY: templates
+    environment: prod
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/publish-templates-prod.yml
+++ b/.github/workflows/publish-templates-prod.yml
@@ -1,0 +1,35 @@
+on:
+  push:
+    branches:
+      - release/templates/*
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      WORKING_DIRECTORY: templates
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '7.0.*'  # Change this to the .NET version you're using
+
+      - name: Read version from Version.props
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+        run: |
+          version=$(grep -oP '<Version>\K[^<]+' Version.props)
+          echo "VERSION=$version-rc.${GITHUB_RUN_NUMBER}" >> $GITHUB_ENV
+
+      - name: Pack
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+        run: dotnet pack --configuration Release --output nupkgs /p:Version=$VERSION
+
+      - name: Publish NuGet packages
+        uses: dansiegel/publish-nuget@v1.2
+        with:
+          filename: '**/*.nupkg'
+          apiKey: ${{ secrets.PREVIEW_NUGET_API_KEY }}
+          feedUrl: ${{ secrets.PREVIEW_NUGET_FEED_URL }}

--- a/.github/workflows/publish-templates-prod.yml
+++ b/.github/workflows/publish-templates-prod.yml
@@ -33,4 +33,4 @@ jobs:
       - name: Publish NuGet packages
         working-directory: ${{ env.WORKING_DIRECTORY }}
         run: |
-          dotnet nuget push "nupkgs/*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source ${{ vars.NUGET_SOURCE_URL }}
+          dotnet nuget push "nupkgs/*.nupkg" --api-key ${{ secrets.TEMPLATES_NUGET_API_KEY }} --source ${{ vars.TEMPLATES_NUGET_SOURCE_URL }}

--- a/.github/workflows/publish-templates-prod.yml
+++ b/.github/workflows/publish-templates-prod.yml
@@ -1,7 +1,9 @@
 on:
   push:
+    tags:
+      - 'templates-v*'
     branches:
-      - release/templates/*
+      - master
 
 jobs:
   publish:
@@ -31,5 +33,5 @@ jobs:
         uses: dansiegel/publish-nuget@v1.2
         with:
           filename: '**/*.nupkg'
-          apiKey: ${{ secrets.PREVIEW_NUGET_API_KEY }}
-          feedUrl: ${{ secrets.PREVIEW_NUGET_FEED_URL }}
+          apiKey: ${{ secrets.TEST_NUGET_API_KEY }}
+          feedUrl: ${{ secrets.TEST_NUGET_FEED_URL }}

--- a/.github/workflows/publish-templates-prod.yml
+++ b/.github/workflows/publish-templates-prod.yml
@@ -2,8 +2,6 @@ on:
   push:
     tags:
       - 'templates-v*'
-    branches:
-      - master
 
 jobs:
   publish:
@@ -14,23 +12,49 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Ensure the full history is fetched so we can check the commit history
+
+      - name: Verify tag is on master branch
+        id: verify_tag
+        run: |
+          # Get the commit SHA of the tag
+          TAG_COMMIT=$(git rev-list -n 1 $GITHUB_REF)
+          # Check if the commit exists on the master branch
+          if git merge-base --is-ancestor $TAG_COMMIT origin/master; then
+            echo "Tag commit is on master branch."
+            echo "IS_ON_MASTER=true" >> $GITHUB_ENV
+          else
+            echo "Tag commit is not on master branch."
+            echo "IS_ON_MASTER=false" >> $GITHUB_ENV
+          fi
+
+      - name: Stop if not on master
+        if: env.IS_ON_MASTER != 'true'
+        run: |
+          echo "This tag was not created from the master branch. Exiting."
+          exit 1
 
       - name: Setup .NET
+        if: env.IS_ON_MASTER == 'true'
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '7.0.*'  # Change this to the .NET version you're using
 
       - name: Read version from Version.props
+        if: env.IS_ON_MASTER == 'true'
         working-directory: ${{ env.WORKING_DIRECTORY }}
         run: |
           version=$(grep -oP '<Version>\K[^<]+' Version.props)
           echo "VERSION=$version" >> $GITHUB_ENV
 
       - name: Pack
+        if: env.IS_ON_MASTER == 'true'
         working-directory: ${{ env.WORKING_DIRECTORY }}
         run: dotnet pack --configuration Release --output nupkgs /p:Version=$VERSION
 
       - name: Publish NuGet packages
+        if: env.IS_ON_MASTER == 'true'
         working-directory: ${{ env.WORKING_DIRECTORY }}
         run: |
           dotnet nuget push "nupkgs/*.nupkg" --api-key ${{ secrets.TEMPLATES_NUGET_API_KEY }} --source ${{ vars.TEMPLATES_NUGET_SOURCE_URL }}

--- a/.github/workflows/publish-templates-staging.yml
+++ b/.github/workflows/publish-templates-staging.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       WORKING_DIRECTORY: templates
-      environment: staging
+    environment: staging
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -31,4 +31,4 @@ jobs:
       - name: Publish NuGet packages
         working-directory: ${{ env.WORKING_DIRECTORY }}
         run: |
-          dotnet nuget push "nupkgs/*.nupkg" --api-key ${{ secrets.TEST_NUGET_API_KEY }} --source https://apiint.nugettest.org/v3/index.json
+          dotnet nuget push "nupkgs/*.nupkg" --api-key ${{ secrets.TEST_NUGET_API_KEY }} --source $TEST_NUGET_SOURCE_URL

--- a/.github/workflows/publish-templates-staging.yml
+++ b/.github/workflows/publish-templates-staging.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Publish NuGet packages
         working-directory: ${{ env.WORKING_DIRECTORY }}
         run: |
-          dotnet nuget push "nupkgs/*.nupkg" --api-key ${{ secrets.TEST_NUGET_API_KEY }} --source ${{ vars.TEST_NUGET_SOURCE_URL }}
+          dotnet nuget push "nupkgs/*.nupkg" --api-key ${{ secrets.TEST_TEMPLATES_NUGET_API_KEY }} --source ${{ vars.TEST_TEMPLATES__NUGET_SOURCE_URL }}

--- a/.github/workflows/publish-templates-staging.yml
+++ b/.github/workflows/publish-templates-staging.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Publish NuGet packages
         working-directory: ${{ env.WORKING_DIRECTORY }}
         run: |
-          dotnet nuget push "nupkgs/*.nupkg" --api-key ${{ secrets.TEST_TEMPLATES_NUGET_API_KEY }} --source ${{ vars.TEST_TEMPLATES__NUGET_SOURCE_URL }}
+          dotnet nuget push "nupkgs/*.nupkg" --api-key ${{ secrets.TEST_TEMPLATES_NUGET_API_KEY }} --source ${{ vars.TEST_TEMPLATES_NUGET_SOURCE_URL }}

--- a/.github/workflows/publish-templates-staging.yml
+++ b/.github/workflows/publish-templates-staging.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Publish NuGet packages
         working-directory: ${{ env.WORKING_DIRECTORY }}
         run: |
-          dotnet nuget push "nupkgs/*.nupkg" --api-key ${{ secrets.TEST_NUGET_API_KEY }} --source https://int.nugettest.org/
+          dotnet nuget push "nupkgs/*.nupkg" --api-key ${{ secrets.TEST_NUGET_API_KEY }} --source ${{ secrets.TEST_NUGET_FEED_URL }}

--- a/.github/workflows/publish-templates-staging.yml
+++ b/.github/workflows/publish-templates-staging.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Publish NuGet packages
         working-directory: ${{ env.WORKING_DIRECTORY }}
         run: |
-          dotnet nuget push "nupkgs/*.nupkg" --api-key ${{ secrets.TEST_NUGET_API_KEY }} --source ${{ env.TEST_NUGET_SOURCE_URL }}
+          dotnet nuget push "nupkgs/*.nupkg" --api-key ${{ secrets.TEST_NUGET_API_KEY }} --source ${{ vars.TEST_NUGET_SOURCE_URL }}

--- a/.github/workflows/publish-templates-staging.yml
+++ b/.github/workflows/publish-templates-staging.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Publish NuGet packages
         working-directory: ${{ env.WORKING_DIRECTORY }}
         run: |
-          dotnet nuget push "nupkgs/*.nupkg" --api-key ${{ secrets.TEST_NUGET_API_KEY }} --source ${{ secrets.TEST_NUGET_FEED_URL }}
+          dotnet nuget push "nupkgs/*.nupkg" --api-key ${{ secrets.TEST_NUGET_API_KEY }} --source https://apiint.nugettest.org/v3/index.json

--- a/.github/workflows/publish-templates-staging.yml
+++ b/.github/workflows/publish-templates-staging.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       WORKING_DIRECTORY: templates
+      environment: staging
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/publish-templates-staging.yml
+++ b/.github/workflows/publish-templates-staging.yml
@@ -1,0 +1,35 @@
+on:
+  push:
+    branches:
+      - release/templates/*
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      WORKING_DIRECTORY: templates
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '7.0.*'  # Change this to the .NET version you're using
+
+      - name: Read version from Version.props
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+        run: |
+          version=$(grep -oP '<Version>\K[^<]+' Version.props)
+          echo "VERSION=$version-rc.${GITHUB_RUN_NUMBER}" >> $GITHUB_ENV
+
+      - name: Pack
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+        run: dotnet pack --configuration Release --output nupkgs /p:Version=$VERSION
+
+      - name: Publish NuGet packages
+        uses: dansiegel/publish-nuget@v1.2
+        with:
+          filename: '**/*.nupkg'
+          apiKey: ${{ secrets.PREVIEW_NUGET_API_KEY }}
+          feedUrl: ${{ secrets.PREVIEW_NUGET_FEED_URL }}

--- a/.github/workflows/publish-templates-staging.yml
+++ b/.github/workflows/publish-templates-staging.yml
@@ -31,5 +31,5 @@ jobs:
         uses: dansiegel/publish-nuget@v1.2
         with:
           filename: '**/*.nupkg'
-          apiKey: ${{ secrets.PREVIEW_NUGET_API_KEY }}
-          feedUrl: ${{ secrets.PREVIEW_NUGET_FEED_URL }}
+          apiKey: ${{ secrets.TEST_NUGET_API_KEY }}
+          feedUrl: ${{ secrets.TEST_NUGET_FEED_URL }}

--- a/.github/workflows/publish-templates-staging.yml
+++ b/.github/workflows/publish-templates-staging.yml
@@ -29,8 +29,6 @@ jobs:
         run: dotnet pack --configuration Release --output nupkgs /p:Version=$VERSION
 
       - name: Publish NuGet packages
-        uses: dansiegel/publish-nuget@v1.2
-        with:
-          filename: '**/*.nupkg'
-          apiKey: ${{ secrets.TEST_NUGET_API_KEY }}
-          feedUrl: ${{ secrets.TEST_NUGET_FEED_URL }}
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+        run: |
+          dotnet nuget push "**/*.nupkg" --api-key ${{ secrets.TEST_NUGET_API_KEY }} --source secrets.TEST_NUGET_FEED_URL

--- a/.github/workflows/publish-templates-staging.yml
+++ b/.github/workflows/publish-templates-staging.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Publish NuGet packages
         working-directory: ${{ env.WORKING_DIRECTORY }}
         run: |
-          dotnet nuget push "**/*.nupkg" --api-key ${{ secrets.TEST_NUGET_API_KEY }} --source secrets.TEST_NUGET_FEED_URL
+          dotnet nuget push "nupkgs/*.nupkg" --api-key ${{ secrets.TEST_NUGET_API_KEY }} --source ${{ secrets.TEST_NUGET_FEED_URL }}

--- a/.github/workflows/publish-templates-staging.yml
+++ b/.github/workflows/publish-templates-staging.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Publish NuGet packages
         working-directory: ${{ env.WORKING_DIRECTORY }}
         run: |
-          dotnet nuget push "nupkgs/*.nupkg" --api-key ${{ secrets.TEST_NUGET_API_KEY }} --source ${{ secrets.TEST_NUGET_FEED_URL }}
+          dotnet nuget push "nupkgs/*.nupkg" --api-key ${{ secrets.TEST_NUGET_API_KEY }} --source https://int.nugettest.org/

--- a/.github/workflows/publish-templates-staging.yml
+++ b/.github/workflows/publish-templates-staging.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Publish NuGet packages
         working-directory: ${{ env.WORKING_DIRECTORY }}
         run: |
-          dotnet nuget push "nupkgs/*.nupkg" --api-key ${{ secrets.TEST_NUGET_API_KEY }} --source $TEST_NUGET_SOURCE_URL
+          dotnet nuget push "nupkgs/*.nupkg" --api-key ${{ secrets.TEST_NUGET_API_KEY }} --source ${{ env.TEST_NUGET_SOURCE_URL }}

--- a/templates/AElf.Contract.Template.csproj
+++ b/templates/AElf.Contract.Template.csproj
@@ -20,6 +20,10 @@
     </ItemGroup>
 
     <ItemGroup>
+        <None Include="README.md" Pack="true" PackagePath="" />
+    </ItemGroup>
+
+    <ItemGroup>
       <PackageReference Include="AElf.Cryptography" Version="1.5.0" />
     </ItemGroup>
 

--- a/templates/AElf.Contract.Template.csproj
+++ b/templates/AElf.Contract.Template.csproj
@@ -12,6 +12,7 @@
         <IncludeContentInPack>true</IncludeContentInPack>
         <IncludeBuildOutput>false</IncludeBuildOutput>
         <ContentTargetFolders>content</ContentTargetFolders>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/templates/Version.props
+++ b/templates/Version.props
@@ -1,0 +1,5 @@
+<Project>
+    <PropertyGroup>
+        <Version>1.0.0</Version>
+    </PropertyGroup>
+</Project>

--- a/templates/Version.props
+++ b/templates/Version.props
@@ -1,5 +1,5 @@
 <Project>
     <PropertyGroup>
-        <Version>1.0.0</Version>
+        <Version>1.0.1</Version>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
Added CI/CD for AElf.ContractTemplates:
staging:
- only triggered when code is pushed to branch "release/templates/v*"
prod:
- only triggered when tag with name "templates-v*" is created on master branch

Needs to setup the following:
Repository Variable:
1. TEST_TEMPLATES_NUGET_SOURCE_URL: https://apiint.nugettest.org/v3/index.json
2. TEMPLATES_NUGET_SOURCE_URL: https://api.nuget.org/v3/index.json
Secrets Variable:
1. staging:
- TEST_TEMPLATES_NUGET_API_KEY: <>
2. prod:
- TEMPLATES_NUGET_API_KEY: <>